### PR TITLE
feat: add stats json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ jobs:
           id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}
       - run: "echo installations: '${{ steps.stats.outputs.installations }}'"
-      - run: "echo suspended: '${{ steps.stats.outputs.suspendedInstallations }}'"
       - run: "echo most popular repositories: '${{ steps.stats.outputs.popular_repositories }}'"
+      - run: "echo stats: '${{ steps.stats.outputs.stats }}'"
 ```
 
 ## Debugging

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,8 @@ outputs:
     description: "Number of suspended installations"
   popular_repositories:
     description: "JSON string for user/organization login and total number of stars of public repositories the app is installed on"
+  stats:
+    description: "JSON string that match output of /probot/stats"
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ async function main() {
     });
     core.setOutput("installations", installations);
     core.setOutput("popular_repositories", JSON.stringify(popularRepositories));
+    core.setOutput("stats", JSON.stringify({ installations, popular: popularRepositories }));
     console.log("done.");
   } catch (error) {
     core.error(error);


### PR DESCRIPTION
- Add a `stats` output that mimics the response of `/probot/stats` endpoint. https://github.com/probot/probot/blob/1c31415759b2f0e03e175ddb3fd51a402f2b77c7/src/apps/stats.ts#L14

- Remove `suspendedInstallations` output which does not exist in the codebase.